### PR TITLE
Improve dashboard empty states and topbar styling

### DIFF
--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
+import { BarChart3 } from "lucide-react";
 import { motion } from "framer-motion";
 import {
   Bar,
@@ -105,7 +106,7 @@ export default function DashboardPage() {
           <CardContent className="h-72">
             {refreshing ? (
               <Skeleton className="h-full w-full" />
-            ) : (
+            ) : chartData.length ? (
               <ResponsiveContainer width="100%" height="100%">
                 <BarChart data={chartData}>
                   <XAxis dataKey="label" stroke="var(--muted-foreground)" />
@@ -122,6 +123,13 @@ export default function DashboardPage() {
                   <Bar dataKey="value" fill="var(--primary)" radius={[8, 8, 0, 0]} />
                 </BarChart>
               </ResponsiveContainer>
+            ) : (
+              <div className="flex h-full flex-col items-center justify-center gap-3 text-center text-sm text-muted-foreground">
+                <div className="rounded-full border border-dashed border-border/80 p-3">
+                  <BarChart3 className="h-6 w-6 text-muted-foreground" aria-hidden="true" />
+                </div>
+                <p>{t("dashboard.chartEmpty")}</p>
+              </div>
             )}
           </CardContent>
         </Card>

--- a/components/Topbar.tsx
+++ b/components/Topbar.tsx
@@ -5,6 +5,7 @@ import { useMemo } from "react";
 import { Command, Moon, SunMedium } from "lucide-react";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
+import { cn } from "./ui/utils";
 import { CompanySwitcher } from "./CompanySwitcher";
 import { useI18n } from "../lib/i18n";
 import {
@@ -24,7 +25,12 @@ export function Topbar() {
   const localeOptions = useMemo(() => availableLocales, [availableLocales]);
 
   return (
-    <header className="sticky top-0 z-40 flex h-16 items-center justify-between border-b border-border bg-background/80 px-4 backdrop-blur">
+    <header
+      className={cn(
+        "sticky top-0 z-40 flex h-16 items-center justify-between border-b border-border backdrop-blur",
+        "bg-background/80 px-4 md:px-6 shadow-sm"
+      )}
+    >
       <div className="flex items-center gap-3">
         <Button
           variant="outline"

--- a/lib/i18n/en.ts
+++ b/lib/i18n/en.ts
@@ -39,6 +39,7 @@ export const en = {
     averageAmount: "Average invoice",
     timeline: "Latest activity",
     chartTitle: "Monthly revenue",
+    chartEmpty: "Not enough data to visualize revenue yet.",
   },
   invoices: {
     title: "Invoices",

--- a/lib/i18n/es.ts
+++ b/lib/i18n/es.ts
@@ -41,6 +41,7 @@ export const es: Dictionary = {
     averageAmount: "Factura media",
     timeline: "Actividad reciente",
     chartTitle: "Ingresos mensuales",
+    chartEmpty: "Aún no hay datos para mostrar los ingresos.",
   },
   invoices: {
     title: "Facturas",


### PR DESCRIPTION
## Summary
- add an empty state to the monthly revenue chart so the card isn’t blank when there’s no data
- localize the empty state copy for both English and Spanish dictionaries
- polish the top navigation bar spacing and elevation with the proper utility classes

## Testing
- npm run lint *(fails: `next` binary not found because dependencies cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d17c92a97c833090752ab57d09bbea